### PR TITLE
Fix #1: rationalize types (and fix 64-bit warnings)

### DIFF
--- a/random-eui64.c
+++ b/random-eui64.c
@@ -41,32 +41,32 @@ Revision history:
 
 int main(int ac, char **av)
 	{
-	int fd, i;
+	int fd, iArg;
 	unsigned char eui[8];
-	unsigned sizeEui;
+	unsigned sizeEui, iEui;
 	char cSep;
 
 	sizeEui = 8;
 	cSep = '-';
 
-	for (i = 1; i < ac; ++i)
+	for (iArg = 1; iArg < ac; ++iArg)
 		{
-		if (strcmp(av[i], "-eui48") == 0)
+		if (strcmp(av[iArg], "-eui48") == 0)
 			sizeEui = 6;
-		else if (strcmp(av[i], "-eui64") == 0)
+		else if (strcmp(av[iArg], "-eui64") == 0)
 			sizeEui = 8;
-		else if (strcmp(av[i], "-colon") == 0)
+		else if (strcmp(av[iArg], "-colon") == 0)
 			cSep = ':';
-		else if (strcmp(av[i], "-dash") == 0)
+		else if (strcmp(av[iArg], "-dash") == 0)
 			cSep = '-';
-		else if (strcmp(av[i], "-h") == 0 ||
-			 strcmp(av[i], "--help") == 0 ||
-			 strcmp(av[i], "-help") == 0)
+		else if (strcmp(av[iArg], "-h") == 0 ||
+			 strcmp(av[iArg], "--help") == 0 ||
+			 strcmp(av[iArg], "-help") == 0)
 			{
 			errx(EXIT_SUCCESS, "usage: [-eui48 -eui64 -colon -dash]");
 			}
 		else
-			errx(EXIT_FAILURE, "invalid argument: %s", av[i]);
+			errx(EXIT_FAILURE, "invalid argument: %s", av[iArg]);
 		}
 
 	fd = open("/dev/random", O_RDONLY);
@@ -78,14 +78,14 @@ int main(int ac, char **av)
 
 	if (read(fd, eui, sizeEui) != sizeEui)
 		{
-		fprintf(stderr, "couldn't read %zu bytes\n", sizeEui);
+		fprintf(stderr, "couldn't read %u bytes\n", sizeEui);
 		exit(1);
 		}
 
 	eui[0] = (eui[0] & ~1) | 2;
-	for (i = 0; i < sizeEui; ++i)
+	for (iEui = 0; iEui < sizeEui; ++iEui)
 		{
-		printf("%02X%c", eui[i], i == sizeEui - 1 ? '\n' : cSep);
+		printf("%02X%c", eui[iEui], iEui == sizeEui - 1 ? '\n' : cSep);
 		}
 
 	return 0;


### PR DESCRIPTION
When I looked at this, I determined that the best way to fix it was to replace `i` by two variables, `iArgs` for scanning args (which must be `int` to match `ac`); and `iEUI` for scanning `eui[]` (which can be `unsigned` to match `sizeEui`). Of course, I also changed the format to expect an `unsigned` when printing `sizeEui`; but the real issue was that I had been lazy in the original code, which made it harder to come up with proper types for everything.

I could have changed the type of `sizeEui` to `size_t`, but as `sizeEui` is only ever set to 6 or 8, that seemed wasteful on 64-bit machines.  (One of the things about being disciplined is that one never likes to slack off, even on tiny programs like this. Writing code requires constant practice, at least for me.)